### PR TITLE
Fix STOMP reconnect resilience to prevent detached consumers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .env
 .env.backup
 .phpunit.result.cache
+.phpunit.cache
 Homestead.json
 Homestead.yaml
 npm-debug.log

--- a/config/stomp.php
+++ b/config/stomp.php
@@ -74,14 +74,37 @@ return [
     'prepend_queues' => true,
 
     /**
-     * Heartbeat which will be requested from server at given millisecond period.
+     * Heartbeat (ms) we ask the SERVER to send us. Default is now non-zero so the client
+     * can detect a half-open / dropped connection (e.g. an idle connection reaped by a
+     * load balancer or NAT) instead of only finding out on the next failed write
+     * ("Was not possible to write frame!"). 0 disables server heartbeats.
      */
-    'receive_heartbeat' => env('STOMP_RECEIVE_HEARTBEAT', 0),
+    'receive_heartbeat' => env('STOMP_RECEIVE_HEARTBEAT', 20000),
 
     /**
-     * Heartbeat which we will be sending to server at given millisecond period.
+     * Heartbeat (ms) we promise to send the server. The broker derives the connection TTL
+     * from this (Artemis: TTL = send_heartbeat * heartBeatToConnectionTtlModifier, default 2x).
+     * IMPORTANT: keep the job `timeout` comfortably below that TTL — heartbeats are only
+     * flushed between polls, so a long-running job does not heartbeat while it runs.
      */
     'send_heartbeat' => env('STOMP_SEND_HEARTBEAT', 50000),
+
+    /**
+     * Reconnect resilience. On a read/write failure the driver reconnects with capped
+     * exponential backoff + jitter, retrying up to `reconnect_tries`. If it still can't
+     * connect it throws, so the queue worker exits and the supervisor restarts a clean
+     * process (rather than spinning forever as a detached, non-consuming worker).
+     */
+    'reconnect_tries' => env('STOMP_RECONNECT_TRIES', 10),
+    'reconnect_backoff_base_ms' => env('STOMP_RECONNECT_BACKOFF_BASE_MS', 200),
+    'reconnect_backoff_max_ms' => env('STOMP_RECONNECT_BACKOFF_MAX_MS', 30000),
+
+    /**
+     * Socket read timeout in seconds (stomp-php Connection::setReadTimeout). Default 0
+     * keeps the historical non-blocking poll behaviour; set > 0 to let stomp-php service
+     * heartbeats during idle reads.
+     */
+    'read_timeout' => env('STOMP_READ_TIMEOUT', 0),
 
     /**
      * Setting consumer-window-size to a value greater than 0 will allow it to receive messages until

--- a/src/Queue/Stomp/ConnectionWrapper.php
+++ b/src/Queue/Stomp/ConnectionWrapper.php
@@ -16,6 +16,8 @@ class ConnectionWrapper
 
         $this->connection = new Connection("$protocol://$host:$port");
 
-        $this->connection->setReadTimeout(0);
+        // Default 0 preserves the historical non-blocking poll behaviour; configurable so
+        // operators can let stomp-php service heartbeats during idle reads.
+        $this->connection->setReadTimeout((int) (Config::get('read_timeout') ?? 0));
     }
 }

--- a/src/Queue/StompQueue.php
+++ b/src/Queue/StompQueue.php
@@ -52,7 +52,6 @@ class StompQueue extends Queue implements QueueInterface
     protected array $subscribedTo = [];
 
     protected LoggerInterface $log;
-    protected int $circuitBreaker = 0;
     protected string $session;
 
     /** @var null|Frame */
@@ -151,7 +150,8 @@ class StompQueue extends Queue implements QueueInterface
      */
     public function later($delay, $job, $data = '', $queue = null)
     {
-        return $this->pushRaw($this->createPayload($job, $data, $queue), $queue);
+        // createPayload signature is ($job, $queue, $data); the args were previously swapped here.
+        return $this->pushRaw($this->createPayload($job, $queue, $data), $queue);
     }
 
     /**
@@ -408,14 +408,17 @@ class StompQueue extends Queue implements QueueInterface
 
             return $frame;
         } catch (Exception $e) {
-            $this->log->error("$this->session [STOMP] Stomp failed to read any data from '$queue' queue. " . $e->getMessage());
+            // Single bounded retry: reconnect once, then attempt one more read. Reconnect()
+            // itself does the backed-off retry loop and throws if it can't recover, which
+            // propagates out and stops the worker (supervisor restarts it). The previous
+            // unbounded `return $this->read($queue)` recursion could exhaust the stack on a
+            // down broker and lose the in-flight frame.
+            $this->log->error("$this->session [STOMP] Failed to read from '$queue': " . $e->getMessage() . " — reconnecting once.");
             $this->reconnect();
 
-            // Need a recursive call as otherwise it loses the original connection, losing the events in the process
-            // NOT WORKING though...
-            $this->log->info("$this->session [STOMP] Re-reading...");
+            $this->log->info("$this->session [STOMP] Re-reading after reconnect...");
 
-            return $this->read($queue);
+            return $this->client->read();
         }
     }
 
@@ -465,41 +468,81 @@ class StompQueue extends Queue implements QueueInterface
         $this->log->info("$this->session [STOMP] Sent alive to {$this->client->getClient()->getSessionId()}");
     }
 
-    protected function reconnect(bool $subscribe = true)
+    /**
+     * Re-establish the broker connection with bounded, backed-off retries.
+     *
+     * Replaces the old recursive circuit-breaker, which (a) never reset its counter,
+     * (b) slept only 100us between tries, and (c) on give-up just returned, leaving the
+     * worker spinning as a "running" but permanently-detached consumer. We now retry with real
+     * exponential backoff + jitter, reset implicitly on success, and THROW on final
+     * give-up so the queue worker exits and the supervisor restarts a clean process.
+     *
+     * @throws ConnectionException when reconnection fails after the configured tries
+     */
+    protected function reconnect(bool $subscribe = true): void
     {
         $this->log->info("$this->session [STOMP] Reconnecting...");
 
         $this->disconnect();
 
-        try {
-            $this->client->getClient()->connect();
-            $newSessionId = $this->client->getClient()->getSessionId();
+        // a fresh session has no subscriptions; clear the cache so subscribeToQueues()
+        // actually re-subscribes (the old code only cleared this on the subscribe path,
+        // so a write-triggered reconnect left a consumer silently un-subscribed).
+        $this->subscribedTo = [];
 
-            $this->log->info("$this->session [STOMP] Reconnected successfully.");
-            $this->log->info("$this->session [STOMP] Switching session to: $newSessionId");
-            $this->session = $newSessionId;
-        } catch (Exception $e) {
-            $this->circuitBreaker++;
+        $maxTries = $this->reconnectMaxTries();
+        $baseMs = (int) (Config::get('reconnect_backoff_base_ms') ?? 200);
+        $maxMs = (int) (Config::get('reconnect_backoff_max_ms') ?? 30000);
 
-            $this->log->error("$this->session [STOMP] Failed reconnecting (tries: {$this->circuitBreaker}),
-            retrying..." . print_r($e->getMessage(), true));
+        for ($attempt = 1; $attempt <= $maxTries; $attempt++) {
+            try {
+                $this->client->getClient()->connect();
+                $this->session = $this->client->getClient()->getSessionId();
+                $this->log->info("$this->session [STOMP] Reconnected successfully on attempt $attempt.");
 
-            if ($this->circuitBreaker <= 5) {
-                usleep(100);
-                $this->reconnect($subscribe);
+                if ($subscribe && $this->client->getClient()->isConnected()) {
+                    $this->log->info("$this->session [STOMP] Connected, subscribing...");
+                    $this->subscribeToQueues();
+                }
+
+                return;
+            } catch (Exception $e) {
+                $sleepMs = self::reconnectBackoffMs($attempt, $baseMs, $maxMs) + random_int(0, 250);
+                $this->log->error("$this->session [STOMP] Reconnect attempt $attempt/$maxTries failed: "
+                    . $e->getMessage() . " — retrying in {$sleepMs}ms");
+                usleep($sleepMs * 1000);
             }
-
-            $this->log->error("$this->session [STOMP] Circuit breaker executed after {$this->circuitBreaker} tries, exiting.");
-
-            return;
         }
 
-        // By this point it should be connected, so it is safe to subscribe
-        if ($subscribe && $this->client->getClient()->isConnected()) {
-            $this->log->info("$this->session [STOMP] Connected, subscribing...");
-            $this->subscribedTo = [];
-            $this->subscribeToQueues();
+        // Out of tries: throw so the worker stops and the supervisor restarts it fresh,
+        // rather than silently looping forever as a zombie that consumes nothing.
+        $msg = "$this->session [STOMP] Reconnect failed after $maxTries attempts; aborting worker.";
+        $this->log->error($msg);
+
+        throw new ConnectionException($msg);
+    }
+
+    protected function reconnectMaxTries(): int
+    {
+        $tries = (int) (Config::get('reconnect_tries') ?? 10);
+
+        return $tries > 0 ? $tries : 1;
+    }
+
+    /**
+     * Capped exponential backoff (milliseconds) for reconnect attempt N (1-based).
+     * Pure/deterministic (jitter is added separately at the call site) so it can be
+     * unit-tested without a broker.
+     */
+    public static function reconnectBackoffMs(int $attempt, int $baseMs, int $maxMs): int
+    {
+        if ($attempt < 1) {
+            $attempt = 1;
         }
+
+        $delay = $baseMs * (2 ** ($attempt - 1));
+
+        return (int) min($maxMs, $delay);
     }
 
     public function disconnect()

--- a/tests/Unit/ReconnectBackoffTest.php
+++ b/tests/Unit/ReconnectBackoffTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Asseco\Stomp\Tests\Unit;
+
+use Asseco\Stomp\Queue\StompQueue;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure unit test for the reconnect backoff curve — no broker / Laravel boot needed.
+ */
+class ReconnectBackoffTest extends TestCase
+{
+    public function test_backoff_grows_exponentially_from_base(): void
+    {
+        $this->assertSame(200, StompQueue::reconnectBackoffMs(1, 200, 30000));
+        $this->assertSame(400, StompQueue::reconnectBackoffMs(2, 200, 30000));
+        $this->assertSame(800, StompQueue::reconnectBackoffMs(3, 200, 30000));
+        $this->assertSame(1600, StompQueue::reconnectBackoffMs(4, 200, 30000));
+    }
+
+    public function test_backoff_is_capped_at_max(): void
+    {
+        // 200 * 2^19 is huge; must be clamped to the configured ceiling
+        $this->assertSame(30000, StompQueue::reconnectBackoffMs(20, 200, 30000));
+    }
+
+    public function test_attempt_below_one_is_clamped_to_first_attempt(): void
+    {
+        $this->assertSame(200, StompQueue::reconnectBackoffMs(0, 200, 30000));
+        $this->assertSame(200, StompQueue::reconnectBackoffMs(-5, 200, 30000));
+    }
+}

--- a/tests/Unit/StompReconnectTest.php
+++ b/tests/Unit/StompReconnectTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Asseco\Stomp\Tests\Unit;
+
+use Asseco\Stomp\Queue\Stomp\ClientWrapper;
+use Asseco\Stomp\Queue\StompQueue;
+use Asseco\Stomp\Tests\TestCase;
+use Mockery;
+use Stomp\Client;
+use Stomp\Exception\ConnectionException;
+use Stomp\StatefulStomp;
+
+/**
+ * Behavioural tests for the reconnect resilience rewrite. The connect() path is
+ * driven through a mocked stomp-php client so no real broker is needed.
+ */
+class StompReconnectTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    /** Build a StompQueue over a mocked client, with fast (jitter-bounded) backoff. */
+    private function makeQueue(StatefulStomp $stateful): StompQueue
+    {
+        config([
+            'queue.connections.stomp.reconnect_tries' => 3,
+            'queue.connections.stomp.reconnect_backoff_base_ms' => 1,
+            'queue.connections.stomp.reconnect_backoff_max_ms' => 1,
+            'queue.connections.stomp.read_queues' => 'eloquent',
+            'queue.connections.stomp.write_queues' => 'eloquent',
+            'queue.connections.stomp.consumer_ack_mode' => 'auto',
+        ]);
+
+        $wrapper = Mockery::mock(ClientWrapper::class);
+        $wrapper->client = $stateful;
+
+        return new class($wrapper) extends StompQueue {
+            public function publicReconnect(bool $subscribe = true): void
+            {
+                $this->reconnect($subscribe);
+            }
+        };
+    }
+
+    public function test_reconnect_throws_after_exhausting_tries(): void
+    {
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getSessionId')->andReturn('sess')->zeroOrMoreTimes();
+        $client->shouldReceive('isConnected')->andReturn(false)->zeroOrMoreTimes();
+        $client->shouldReceive('disconnect')->andReturnNull()->zeroOrMoreTimes();
+        // the headline assertion: exactly `reconnect_tries` (3) connect attempts, all failing
+        $client->shouldReceive('connect')->times(3)->andThrow(new ConnectionException('broker down'));
+
+        $stateful = Mockery::mock(StatefulStomp::class);
+        $stateful->shouldReceive('getClient')->andReturn($client);
+
+        $queue = $this->makeQueue($stateful);
+
+        $this->expectException(ConnectionException::class);
+        $queue->publicReconnect();
+    }
+
+    public function test_reconnect_recovers_without_throwing_when_a_later_attempt_succeeds(): void
+    {
+        $attempts = 0;
+
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('getSessionId')->andReturn('sess')->zeroOrMoreTimes();
+        $client->shouldReceive('isConnected')->andReturn(true)->zeroOrMoreTimes();
+        $client->shouldReceive('disconnect')->andReturnNull()->zeroOrMoreTimes();
+        // first attempt fails, second succeeds → no exception, no give-up
+        $client->shouldReceive('connect')->times(2)->andReturnUsing(function () use (&$attempts) {
+            $attempts++;
+            if ($attempts === 1) {
+                throw new ConnectionException('transient blip');
+            }
+
+            return true;
+        });
+
+        $stateful = Mockery::mock(StatefulStomp::class);
+        $stateful->shouldReceive('getClient')->andReturn($client);
+        // resubscribe path
+        $stateful->shouldReceive('getSubscriptions')->andReturn(Mockery::mock(['getSubscription' => null]))->zeroOrMoreTimes();
+        $stateful->shouldReceive('subscribe')->andReturnNull()->zeroOrMoreTimes();
+
+        $queue = $this->makeQueue($stateful);
+
+        $queue->publicReconnect();
+
+        $this->assertSame(2, $attempts, 'should stop retrying as soon as a connect succeeds');
+    }
+}


### PR DESCRIPTION
## Why

Under a brief broker outage or a dropped connection, a Laravel STOMP worker could end up **"running" but permanently detached** — 0 consumers on its queue while messages pile up unread (observed in production as a queue with a 13k backlog and `consumerCount: 0`), and/or a tight `Was not possible to write frame!` reconnect loop.

Root causes in `StompQueue`:

- **`reconnect()` circuit breaker was fatally broken:** the `circuitBreaker` counter was an instance field that was **never reset**, retries slept only `usleep(100)` (100 microseconds), and on give-up the method simply `return`ed. So a ~1s outage blew past the 5-try cap in well under a millisecond, and from then on — for the whole process lifetime — every reconnect got a single attempt and surrendered, while the worker kept polling and consuming nothing.
- **`read()` recovered via unbounded recursion** (`return $this->read($queue)`), risking stack exhaustion / lost frames on a down broker (the code even carried a `// NOT WORKING though...` note).
- **The write-path `reconnect(false)` never cleared `subscribedTo`**, so after such a reconnect a consumer was silently un-subscribed on the new session.
- **Heartbeat/keepalive gaps:** `receive_heartbeat` defaulted to `0`, so the client never asked the server for heartbeats and could only discover a half-open/idle-reaped connection on the next failed write.

## What changed

- **`reconnect()` rewritten:** bounded loop with **capped exponential backoff + jitter**, implicitly resets on success, and **throws `ConnectionException` on final give-up** so the worker exits and the supervisor restarts a clean process instead of spinning as a zombie.
- **`read()`:** single bounded retry (reconnect once, one re-read) instead of unbounded recursion.
- **`reconnect()` always clears `subscribedTo`** so a fresh session always re-subscribes.
- **Config:** `receive_heartbeat` default `0 → 20000`; new configurable `read_timeout` (default `0`, preserves current non-blocking poll), `reconnect_tries`, `reconnect_backoff_base_ms`, `reconnect_backoff_max_ms`; documented the **job `timeout` < broker connection-TTL** invariant.
- **Bug fix:** `later()` passed `createPayload($job, $data, $queue)` — args swapped vs the `($job, $queue, $data)` signature.

## Tests

New `tests/Unit/`:
- `ReconnectBackoffTest` — the backoff curve (exponential, capped, clamped).
- `StompReconnectTest` — reconnect **throws after exhausting tries**, and **stops retrying as soon as a connect succeeds** (mocked stomp-php client, no broker needed).

All green (PHPUnit 10, PHP 8.5): `5 tests, 9 assertions`.

## Notes / follow-ups

- Backward compatible except the `receive_heartbeat` default change (`0 → 20000`) — override via `STOMP_RECEIVE_HEARTBEAT` if you need the old behavior.
- **Not included (deliberate):** flipping the default `consumer_ack_mode` from `auto` → `client`. With `auto`, prefetched-but-unprocessed messages are lost on a worker crash; switching the default is a broader behavioral change worth its own discussion.
